### PR TITLE
Add metadata to extension.properties

### DIFF
--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=@extname@
-description=The extension description can be customized by editing the extension.properties file.
-author=
+description=Facilitates the analysis of Golang binaries using Ghidra
+author=mooncat-greenpy
 createdOn=
 version=@extversion@


### PR DESCRIPTION
Adding extension description and author information for the Ghidra extension manager.

Noticed the fields are blank while working on https://github.com/NixOS/nixpkgs/pull/350850