### PR TITLE
Add more mechanisms for recognizing label names

### DIFF
--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/function/GolangFunction.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/function/GolangFunction.java
@@ -508,12 +508,12 @@ public class GolangFunction {
 	}
 
 	private boolean init_func() {
-		boolean is_go118=false;
-		if(go_bin.ge_go_version(GolangVersion.GO_1_18_LOWEST)) {
-			is_go118=true;
-		}
 		func_addr=info.get_func_addr();
 		if (func_addr==null) {
+			return false;
+		}
+
+		if(!init_func_name()) {
 			return false;
 		}
 
@@ -526,15 +526,19 @@ public class GolangFunction {
 			func=go_bin.get_function(func_addr).orElse(null);
 		}
 		if(func==null) {
+			// Stripped binaries may not have pre-existing functions; ensure code exists before creating one.
+			disassemble();
+			go_bin.create_function(func_name, func_addr);
+			func=go_bin.get_function(func_addr).orElse(null);
+		}
+		if(func==null) {
 			Logger.append_message(String.format("Failed to get function: %s", func_addr));
 			return false;
 		}
 
-		if(!init_func_name()) {
-			return false;
-		}
 		if(!init_file_line_map()) {
-			return false;
+			file_line_comment_map=new HashMap<>();
+			Logger.append_message(String.format("Failed to init file line map: addr=%s, name=%s", func_addr, func_name));
 		}
 
 		if(!init_args_size()) {
@@ -581,10 +585,12 @@ public class GolangFunction {
 		init_regs_ret();
 
 		if(!init_params_var()) {
-			return false;
+			params=new ArrayList<>();
+			Logger.append_message(String.format("Failed to init params: addr=%s, name=%s", func_addr, func_name));
 		}
 		if(!init_ret_var()) {
-			return false;
+			ret_param=null;
+			Logger.append_message(String.format("Failed to init return: addr=%s, name=%s", func_addr, func_name));
 		}
 
 		return true;

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
@@ -89,9 +89,13 @@ public class FuncInfo {
 		Address func_end_addr;
 		try {
 			int functab_field_size=is_go118?4:pointer_size;
+			long text=0;
+			if(is_go118) {
+				text=get_go118_text_base(pcheader_base, false);
+			}
 			func_addr_value=go_bin.get_address_value(tab_addr, functab_field_size);
 			if(is_go118) {
-				func_addr_value+=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
+				func_addr_value+=text;
 			}
 			func_addr = go_bin.get_address(func_addr_value);
 
@@ -104,7 +108,7 @@ public class FuncInfo {
 
 			func_end_value=go_bin.get_address_value(tab_addr, functab_field_size*2, functab_field_size);
 			if(is_go118) {
-				func_end_value+=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
+				func_end_value+=text;
 			}
 			func_end_addr=go_bin.get_address(func_end_value);
 		} catch (BinaryAccessException e) {
@@ -158,12 +162,8 @@ public class FuncInfo {
 
 	private void parse_func_info(GolangBinary go_bin, Address func_list_base, FuncInfoTab info_tab) throws InvalidBinaryStructureException {
 		boolean is_go118=false;
-		boolean is_go126=false;
 		if(go_bin.ge_go_version(GolangVersion.GO_1_18_LOWEST)) {
 			is_go118=true;
-		}
-		if(go_bin.ge_go_version(GolangVersion.GO_1_26_LOWEST)) {
-			is_go126=true;
 		}
 
 		int pointer_size=go_bin.get_pointer_size();
@@ -176,14 +176,7 @@ public class FuncInfo {
 
 			func_entry_value=go_bin.get_address_value(info_tab.get_info_addr(), functab_field_size);
 			if(is_go118) {
-				text=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
-				if (text==0) {
-					ModuleData module_data=go_bin.get_module_data().orElse(null);
-					if (module_data==null) {
-						throw new InvalidBinaryStructureException("Invalid text addr");
-					}
-					text=module_data.get_text_addr().getOffset();
-				}
+				text=get_go118_text_base(pcheader_base, true);
 				func_entry_value+=text;
 			}
 		} catch (BinaryAccessException e) {
@@ -192,7 +185,12 @@ public class FuncInfo {
 		if (func_entry_value==0) {
 			throw new InvalidBinaryStructureException("Invalid FuncInfo.func_addr");
 		}
-		if (info_tab.get_func_addr().getOffset()+(is_go126?text:0)!=func_entry_value && !force) {
+		long tab_func_addr=info_tab.get_func_addr().getOffset();
+		boolean is_func_addr_matched=tab_func_addr==func_entry_value;
+		if(!is_func_addr_matched && is_go118 && text!=0) {
+			is_func_addr_matched=(tab_func_addr+text)==func_entry_value;
+		}
+		if (!is_func_addr_matched && !force) {
 			throw new InvalidBinaryStructureException(String.format("FuncInfo.func_addr mismatch: %x != %x", info_tab.get_func_addr().getOffset(), func_entry_value));
 		}
 
@@ -207,5 +205,30 @@ public class FuncInfo {
 		} catch (BinaryAccessException e) {
 			throw new InvalidBinaryStructureException(String.format("Invalid FuncInfo: message=%s", e.getMessage()));
 		}
+	}
+
+	private long get_go118_text_base(Address pcheader_base, boolean require_non_zero) throws BinaryAccessException, InvalidBinaryStructureException {
+		int pointer_size=go_bin.get_pointer_size();
+		long text=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
+		if(text!=0) {
+			return text;
+		}
+
+		ModuleData module_data=go_bin.get_module_data().orElse(null);
+		if(module_data!=null) {
+			text=module_data.get_text_addr().getOffset();
+		}
+		if(text==0) {
+			Address text_base=go_bin.get_text_base().orElse(null);
+			if(text_base!=null) {
+				text=text_base.getOffset();
+			}
+		}
+
+		if(require_non_zero && text==0) {
+			throw new InvalidBinaryStructureException("Invalid text addr");
+		}
+
+		return text;
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # GolangAnalyzerExtension
+## Update (2026-04-09)
+Added support improvements for recovering function metadata from .pclntab in stripped Go binaries (for example binaries built with -ldflags="-s -w").
+
+What was changed:
+- Improved Go 1.18+ function parsing to handle cases where PcHeader textStart is zero by falling back to moduledata.text.
+- Added a second fallback to .text section start when moduledata is unavailable.
+- Relaxed function entry consistency checks to accept both absolute functab addresses and text-relative functab offsets.
+- Improved stripped-binary handling by creating/disassembling functions from pclntab entries when functions are not already materialized.
+- This improves function name recovery from pclntab metadata when symbols are stripped.
+
 The GolangAnalyzerExtension facilitates the analysis of Golang binaries using Ghidra.
 It supports go1.6 through go1.26.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # GolangAnalyzerExtension
-
 The GolangAnalyzerExtension facilitates the analysis of Golang binaries using Ghidra.
 It supports go1.6 through go1.26.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,4 @@
 # GolangAnalyzerExtension
-## Update (2026-04-09)
-Added support improvements for recovering function metadata from .pclntab in stripped Go binaries (for example binaries built with -ldflags="-s -w").
-
-What was changed:
-- Improved Go 1.18+ function parsing to handle cases where PcHeader textStart is zero by falling back to moduledata.text.
-- Added a second fallback to .text section start when moduledata is unavailable.
-- Relaxed function entry consistency checks to accept both absolute functab addresses and text-relative functab offsets.
-- Improved stripped-binary handling by creating/disassembling functions from pclntab entries when functions are not already materialized.
-- This improves function name recovery from pclntab metadata when symbols are stripped.
 
 The GolangAnalyzerExtension facilitates the analysis of Golang binaries using Ghidra.
 It supports go1.6 through go1.26.


### PR DESCRIPTION
> Note: GitHub Copilot with GPT-5.3-Codex was primarily used for applying this change.

**Summary**
This PR improves function recovery in Go 1.18+ stripped binaries by adding robust fallbacks for determining the `.text` section base and normalizing offsets from `.pclntab`. Previously, stripped binaries had missing function objects and names because the text base was zero.

**Changes**

1. **Multi-source text base resolution**: Try `pcHeader.textStart`, then `moduledata.text`, then `.text` section start.
2. **Offset-to-address normalization**: Convert function table entries into actual virtual addresses.
3. **Flexible address checks**: Accept both absolute addresses and text-relative offsets.
4. **Name-first recovery flow**: Extract function names before creating function objects.
5. **Function materialization fallback**: Attempt creation or disassembly if a function is missing.
6. **Graceful degradation**: Keep functions and names even if file-line/param/return info fails.
7. **Continue-on-error iteration**: Process all entries even if some are malformed.

**Impact**

* Functions in stripped Go binaries are now detected and renamed by the extension.
* Works with binaries built using `go build -ldflags="-s -w"`, e.g., Go 1.26.2.

**Before / After**

* **Before:** Only Ghidra analyzer detected functions; extension had no effect.
* **After:** Functions detected and renamed by the extension.





