### PR TITLE
WASM support

### DIFF
--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
@@ -1,9 +1,11 @@
 package golanganalyzerextension;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import ghidra.program.model.address.Address;
 import ghidra.program.model.data.VoidDataType;
@@ -265,25 +267,43 @@ public class FunctionModifier {
 		Address addr=gofunc.get_func_addr();
 		Map<Integer, FileLine> comment_map=gofunc.get_file_line_comment_map();
 
-		Map<Integer, Address> wasm_pc_to_addr=null;
 		if (go_bin.is_wasm()) {
-			wasm_pc_to_addr=build_wasm_pc_marker_map(gofunc);
+			add_file_line_comment_wasm(gofunc, comment_map);
+			return;
 		}
 
 		for(Integer key: comment_map.keySet()) {
 			try {
-				Address comment_addr;
-				if (wasm_pc_to_addr != null) {
-					comment_addr = wasm_pc_to_addr.get(key);
-					if (comment_addr == null) {
-						// No PC marker for this pseudo-PC in the WASM body; skip rather than
-						// place the annotation at a misleading byte offset.
-						continue;
-					}
-				} else {
-					comment_addr = go_bin.get_address(addr, key);
+				go_bin.set_comment(go_bin.get_address(addr, key), ghidra.program.model.listing.CodeUnit.PRE_COMMENT, comment_map.get(key).toString());
+			} catch (BinaryAccessException e) {
+				Logger.append_message(String.format("Failed to add file line comment: addr=%s, name=%s, message=%s", gofunc.get_func_addr(), gofunc.get_func_name(), e.getMessage()));
+			}
+		}
+	}
+
+	private void add_file_line_comment_wasm(GolangFunction gofunc, Map<Integer, FileLine> comment_map) {
+		TreeMap<Integer, Address> markers = new TreeMap<>(build_wasm_pc_marker_map(gofunc));
+		if (markers.isEmpty()) {
+			return;
+		}
+		List<Integer> keys = new ArrayList<>(comment_map.keySet());
+		Collections.sort(keys);
+		for (int i = 0; i < keys.size(); i++) {
+			int key = keys.get(i);
+			int next_key = (i + 1 < keys.size()) ? keys.get(i + 1) : Integer.MAX_VALUE;
+			Address target = markers.get(key);
+			if (target == null) {
+				// Go didn't emit a runtime-PC marker at this pseudo-PC. Fall back to the
+				// closest marker that still belongs to this pcln entry's range
+				// [key, next_key) so we don't bleed the annotation into the next line range.
+				Map.Entry<Integer, Address> ceiling = markers.ceilingEntry(key);
+				if (ceiling == null || ceiling.getKey() >= next_key) {
+					continue;
 				}
-				go_bin.set_comment(comment_addr, ghidra.program.model.listing.CodeUnit.PRE_COMMENT, comment_map.get(key).toString());
+				target = ceiling.getValue();
+			}
+			try {
+				go_bin.set_comment(target, ghidra.program.model.listing.CodeUnit.PRE_COMMENT, comment_map.get(key).toString());
 			} catch (BinaryAccessException e) {
 				Logger.append_message(String.format("Failed to add file line comment: addr=%s, name=%s, message=%s", gofunc.get_func_addr(), gofunc.get_func_name(), e.getMessage()));
 			}

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
@@ -195,6 +195,12 @@ public class FunctionModifier {
 	}
 
 	private boolean init_hardcode_functions(){
+		// On WASM the WasmLoader has already created a function for every entry in the
+		// module (often >1000). The memcpy/memset disassembly heuristics here aren't
+		// meaningful for WASM and just produce noisy logs, so skip the pass.
+		if (go_bin.is_wasm()) {
+			return true;
+		}
 		for(Function func : go_bin.get_functions()) {
 			Address entry_addr=func.getEntryPoint();
 			GolangFunction find=gofunc_list.stream().filter(v -> v.get_func_addr().equals(entry_addr)).findFirst().orElse(null);

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/FunctionModifier.java
@@ -1,6 +1,7 @@
 package golanganalyzerextension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -8,7 +9,10 @@ import ghidra.program.model.address.Address;
 import ghidra.program.model.data.VoidDataType;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Function.FunctionUpdateType;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.InstructionIterator;
 import ghidra.program.model.listing.Parameter;
+import ghidra.program.model.scalar.Scalar;
 import ghidra.program.model.symbol.SourceType;
 import golanganalyzerextension.exceptions.InvalidBinaryStructureException;
 import golanganalyzerextension.function.FileLine;
@@ -261,12 +265,72 @@ public class FunctionModifier {
 		Address addr=gofunc.get_func_addr();
 		Map<Integer, FileLine> comment_map=gofunc.get_file_line_comment_map();
 
+		Map<Integer, Address> wasm_pc_to_addr=null;
+		if (go_bin.is_wasm()) {
+			wasm_pc_to_addr=build_wasm_pc_marker_map(gofunc);
+		}
+
 		for(Integer key: comment_map.keySet()) {
 			try {
-				go_bin.set_comment(go_bin.get_address(addr, key), ghidra.program.model.listing.CodeUnit.PRE_COMMENT, comment_map.get(key).toString());
+				Address comment_addr;
+				if (wasm_pc_to_addr != null) {
+					comment_addr = wasm_pc_to_addr.get(key);
+					if (comment_addr == null) {
+						// No PC marker for this pseudo-PC in the WASM body; skip rather than
+						// place the annotation at a misleading byte offset.
+						continue;
+					}
+				} else {
+					comment_addr = go_bin.get_address(addr, key);
+				}
+				go_bin.set_comment(comment_addr, ghidra.program.model.listing.CodeUnit.PRE_COMMENT, comment_map.get(key).toString());
 			} catch (BinaryAccessException e) {
 				Logger.append_message(String.format("Failed to add file line comment: addr=%s, name=%s, message=%s", gofunc.get_func_addr(), gofunc.get_func_name(), e.getMessage()));
 			}
 		}
+	}
+
+	// Go's WASM emits an `i64.const (funcEntry<<16)|pseudoPC; i64.store local_8` pair
+	// at the start of each Go-level instruction to update the runtime PC global. By
+	// scanning the function body for these constants we recover a mapping from each
+	// pcln pseudo-PC value to its actual byte address within the WASM body. Without
+	// this, treating the pcln key as a byte offset crams every source-line annotation
+	// into the dispatch-chain bytes at the start of the function.
+	private Map<Integer, Address> build_wasm_pc_marker_map(GolangFunction gofunc) {
+		Map<Integer, Address> map = new HashMap<>();
+		Function func = gofunc.get_func();
+		if (func == null) {
+			return map;
+		}
+		int func_entry = -1;
+		InstructionIterator iter = func.getProgram().getListing().getInstructions(func.getBody(), true);
+		while (iter.hasNext()) {
+			Instruction inst = iter.next();
+			if (!inst.getMnemonicString().equals("i64.const")) {
+				continue;
+			}
+			Object[] objs = inst.getOpObjects(0);
+			for (Object o : objs) {
+				if (!(o instanceof Scalar)) {
+					continue;
+				}
+				long val = ((Scalar) o).getUnsignedValue();
+				int upper = (int) (val >>> 16);
+				int lower = (int) (val & 0xFFFF);
+				// PC markers have a funcEntry upper word that's well above any plausible
+				// numeric constant a function would push (Go's first user funcEntry is
+				// 0x1000 in our binaries). Anchor on the first such i64.const we see.
+				if (upper < 0x100) {
+					continue;
+				}
+				if (func_entry == -1) {
+					func_entry = upper;
+				}
+				if (upper == func_entry) {
+					map.putIfAbsent(lower, inst.getAddress());
+				}
+			}
+		}
+		return map;
 	}
 }

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/GolangAnalyzerExtensionAnalyzer.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/GolangAnalyzerExtensionAnalyzer.java
@@ -101,7 +101,7 @@ public class GolangAnalyzerExtensionAnalyzer extends AbstractAnalyzer {
 			}
 
 			if(go_bin.is_wasm()) {
-				WasmReferenceLinker wasm_linker=new WasmReferenceLinker(program, go_bin);
+				WasmReferenceLinker wasm_linker=new WasmReferenceLinker(program, go_bin, service);
 				wasm_linker.link();
 			}
 		} catch(InvalidBinaryStructureException e) {

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/GolangAnalyzerExtensionAnalyzer.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/GolangAnalyzerExtensionAnalyzer.java
@@ -99,6 +99,11 @@ public class GolangAnalyzerExtensionAnalyzer extends AbstractAnalyzer {
 				StringExtractor str_extractor=new StringExtractor(go_bin, service);
 				str_extractor.modify();
 			}
+
+			if(go_bin.is_wasm()) {
+				WasmReferenceLinker wasm_linker=new WasmReferenceLinker(program, go_bin);
+				wasm_linker.link();
+			}
 		} catch(InvalidBinaryStructureException e) {
 			Logger.append_message(e.getMessage());
 		} catch(Exception e) {

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/WasmReferenceLinker.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/WasmReferenceLinker.java
@@ -1,5 +1,8 @@
 package golanganalyzerextension;
 
+import java.util.List;
+import java.util.Map;
+
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.listing.Data;
@@ -17,7 +20,10 @@ import ghidra.program.model.symbol.ReferenceManager;
 import ghidra.program.model.symbol.SourceType;
 import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolTable;
+import golanganalyzerextension.datatype.GolangDatatypeRecord;
+import golanganalyzerextension.function.GolangFunctionRecord;
 import golanganalyzerextension.gobinary.GolangBinary;
+import golanganalyzerextension.service.GolangAnalyzerExtensionService;
 
 // Walks WASM function bodies and attaches DATA references from i32.const/i64.const
 // instructions to their linear-memory targets when those targets have a defined data
@@ -25,16 +31,18 @@ import golanganalyzerextension.gobinary.GolangBinary;
 // constants like `0x36878`; with it the decompiler prints the symbol name instead.
 public class WasmReferenceLinker {
 
-	private static final long CODE_BASE = 0x80000000L;
+	// Depends on https://github.com/nneonneo/ghidra-wasm-plugin
 	private static final long MEMORY_LOW = 0x1000L;
 	private static final long MEMORY_HIGH = 0x7f000000L;
 
 	private final Program program;
 	private final GolangBinary go_bin;
+	private final GolangAnalyzerExtensionService service;
 
-	public WasmReferenceLinker(Program program, GolangBinary go_bin) {
+	public WasmReferenceLinker(Program program, GolangBinary go_bin, GolangAnalyzerExtensionService service) {
 		this.program = program;
 		this.go_bin = go_bin;
+		this.service = service;
 	}
 
 	public void link() {
@@ -50,13 +58,13 @@ public class WasmReferenceLinker {
 			return;
 		}
 
-		FunctionIterator funcs = program.getFunctionManager().getFunctions(true);
-		while (funcs.hasNext()) {
-			Function func = funcs.next();
-			Address entry = func.getEntryPoint();
-			if (entry.getOffset() < CODE_BASE) {
+		List<GolangFunctionRecord> gofuncs = service.get_function_list();
+		for (GolangFunctionRecord gofunc : gofuncs) {
+			Function func=go_bin.get_function(gofunc.get_func_addr()).orElse(null);
+			if (func == null) {
 				continue;
 			}
+			Address entry = func.getEntryPoint();
 			Instruction inst = listing.getInstructionAt(entry);
 			while (inst != null && func.getBody().contains(inst.getAddress())) {
 				try_link(inst, ram, listing, sym_tab, ref_mgr, eq_tab);
@@ -70,6 +78,7 @@ public class WasmReferenceLinker {
 		if (!mnem.equals("i64.const") && !mnem.equals("i32.const")) {
 			return;
 		}
+		Map<Long, GolangDatatypeRecord> datatype_map = service.get_datatype_map();
 		int num_ops = inst.getNumOperands();
 		for (int op = 0; op < num_ops; op++) {
 			Object[] objs = inst.getOpObjects(op);
@@ -78,7 +87,7 @@ public class WasmReferenceLinker {
 					continue;
 				}
 				long val = ((Scalar) o).getUnsignedValue();
-				if (val < MEMORY_LOW || val >= MEMORY_HIGH) {
+				if ((val < MEMORY_LOW || val >= MEMORY_HIGH) && !datatype_map.containsKey(val)) {
 					continue;
 				}
 				Address target;
@@ -102,16 +111,20 @@ public class WasmReferenceLinker {
 
 	private String pick_label(Address target, Listing listing, SymbolTable sym_tab) {
 		Symbol s = sym_tab.getPrimarySymbol(target);
-		if (s != null) {
-			SourceType src = s.getSource();
-			if (src == SourceType.USER_DEFINED || src == SourceType.IMPORTED) {
-				return s.getName();
-			}
+		if (s == null) {
+			return null;
 		}
-		Data defined = listing.getDefinedDataAt(target);
-		if (defined != null && s != null) {
+
+		SourceType src = s.getSource();
+		if (src == SourceType.USER_DEFINED || src == SourceType.IMPORTED) {
 			return s.getName();
 		}
+
+		Data defined = listing.getDefinedDataAt(target);
+		if (defined != null) {
+			return s.getName();
+		}
+
 		return null;
 	}
 

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/WasmReferenceLinker.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/WasmReferenceLinker.java
@@ -1,0 +1,144 @@
+package golanganalyzerextension;
+
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionIterator;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.scalar.Scalar;
+import ghidra.program.model.symbol.Equate;
+import ghidra.program.model.symbol.EquateTable;
+import ghidra.program.model.symbol.RefType;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceManager;
+import ghidra.program.model.symbol.SourceType;
+import ghidra.program.model.symbol.Symbol;
+import ghidra.program.model.symbol.SymbolTable;
+import golanganalyzerextension.gobinary.GolangBinary;
+
+// Walks WASM function bodies and attaches DATA references from i32.const/i64.const
+// instructions to their linear-memory targets when those targets have a defined data
+// item or a labeled symbol. Without this, Go's WASM pointer loads decompile as raw
+// constants like `0x36878`; with it the decompiler prints the symbol name instead.
+public class WasmReferenceLinker {
+
+	private static final long CODE_BASE = 0x80000000L;
+	private static final long MEMORY_LOW = 0x1000L;
+	private static final long MEMORY_HIGH = 0x7f000000L;
+
+	private final Program program;
+	private final GolangBinary go_bin;
+
+	public WasmReferenceLinker(Program program, GolangBinary go_bin) {
+		this.program = program;
+		this.go_bin = go_bin;
+	}
+
+	public void link() {
+		if (!go_bin.is_wasm()) {
+			return;
+		}
+		ReferenceManager ref_mgr = program.getReferenceManager();
+		SymbolTable sym_tab = program.getSymbolTable();
+		EquateTable eq_tab = program.getEquateTable();
+		Listing listing = program.getListing();
+		AddressSpace ram = program.getAddressFactory().getAddressSpace("ram");
+		if (ram == null) {
+			return;
+		}
+
+		FunctionIterator funcs = program.getFunctionManager().getFunctions(true);
+		while (funcs.hasNext()) {
+			Function func = funcs.next();
+			Address entry = func.getEntryPoint();
+			if (entry.getOffset() < CODE_BASE) {
+				continue;
+			}
+			Instruction inst = listing.getInstructionAt(entry);
+			while (inst != null && func.getBody().contains(inst.getAddress())) {
+				try_link(inst, ram, listing, sym_tab, ref_mgr, eq_tab);
+				inst = inst.getNext();
+			}
+		}
+	}
+
+	private void try_link(Instruction inst, AddressSpace ram, Listing listing, SymbolTable sym_tab, ReferenceManager ref_mgr, EquateTable eq_tab) {
+		String mnem = inst.getMnemonicString();
+		if (!mnem.equals("i64.const") && !mnem.equals("i32.const")) {
+			return;
+		}
+		int num_ops = inst.getNumOperands();
+		for (int op = 0; op < num_ops; op++) {
+			Object[] objs = inst.getOpObjects(op);
+			for (Object o : objs) {
+				if (!(o instanceof Scalar)) {
+					continue;
+				}
+				long val = ((Scalar) o).getUnsignedValue();
+				if (val < MEMORY_LOW || val >= MEMORY_HIGH) {
+					continue;
+				}
+				Address target;
+				try {
+					target = ram.getAddress(val);
+				} catch (Exception e) {
+					continue;
+				}
+				String label = pick_label(target, listing, sym_tab);
+				if (label == null) {
+					continue;
+				}
+				if (!reference_exists(inst, target, op, ref_mgr)) {
+					ref_mgr.addMemoryReference(inst.getAddress(), target, RefType.DATA, SourceType.ANALYSIS, op);
+				}
+				attach_equate(inst, op, val, label, eq_tab);
+				return;
+			}
+		}
+	}
+
+	private String pick_label(Address target, Listing listing, SymbolTable sym_tab) {
+		Symbol s = sym_tab.getPrimarySymbol(target);
+		if (s != null) {
+			SourceType src = s.getSource();
+			if (src == SourceType.USER_DEFINED || src == SourceType.IMPORTED) {
+				return s.getName();
+			}
+		}
+		Data defined = listing.getDefinedDataAt(target);
+		if (defined != null && s != null) {
+			return s.getName();
+		}
+		return null;
+	}
+
+	private void attach_equate(Instruction inst, int op, long val, String label, EquateTable eq_tab) {
+		// Prefix avoids decompiler ambiguity between the equate (a substitution for a
+		// scalar value) and a same-named code/data symbol.
+		String eq_name = "&" + label;
+		Equate eq = eq_tab.getEquate(eq_name);
+		try {
+			if (eq == null) {
+				eq = eq_tab.createEquate(eq_name, val);
+			} else if (eq.getValue() != val) {
+				return;
+			}
+			eq.addReference(inst.getAddress(), op);
+		} catch (Exception e) {
+			// silent: invalid name or duplicate reference
+		}
+	}
+
+	private boolean reference_exists(Instruction inst, Address target, int op_idx, ReferenceManager ref_mgr) {
+		Reference[] refs = ref_mgr.getReferencesFrom(inst.getAddress(), op_idx);
+		for (Reference r : refs) {
+			if (r.getToAddress().equals(target)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
@@ -64,6 +64,17 @@ public class FuncInfo {
 		return;
 	}
 
+	// Go WASM funtab encoding: each entry is a 32-bit "runtime funcEntry" value that
+	// increments by 1 between consecutive user functions, starting at some constant for
+	// the first entry. The mapping to wasm-module funcID is:
+	//     wasm_func_idx = (current_entry - first_entry) + num_imports
+	private static int wasm_entry_to_func_idx(GolangBinary go_bin, Address func_list_base, long current_entry, int field_size) throws BinaryAccessException {
+		long base_entry = go_bin.get_address_value(func_list_base, field_size);
+		// For Go ≥1.18, pcheader.textStart on WASM is 0, so we don't add it here either.
+		long delta = current_entry - base_entry;
+		return (int) (delta + go_bin.get_wasm_num_imports());
+	}
+
 	private FuncInfoTab parse_func_info_tab(GolangBinary go_bin, Address func_list_base, Address tab_addr) throws InvalidBinaryStructureException {
 		boolean is_go116=false;
 		boolean is_go118=false;
@@ -80,6 +91,7 @@ public class FuncInfo {
 
 		int pointer_size=go_bin.get_pointer_size();
 		Address pcheader_base=go_bin.get_pcheader_base();
+		boolean is_wasm=go_bin.is_wasm();
 
 		long func_addr_value;
 		Address func_addr;
@@ -93,7 +105,12 @@ public class FuncInfo {
 			if(is_go118) {
 				func_addr_value+=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
 			}
-			func_addr = go_bin.get_address(func_addr_value);
+			if(is_wasm) {
+				int func_idx=wasm_entry_to_func_idx(go_bin, func_list_base, func_addr_value, functab_field_size);
+				func_addr = go_bin.get_wasm_func_addr(func_idx);
+			} else {
+				func_addr = go_bin.get_address(func_addr_value);
+			}
 
 			info_offset=go_bin.get_address_value(tab_addr, functab_field_size, functab_field_size);
 			if(is_go116) {
@@ -106,7 +123,15 @@ public class FuncInfo {
 			if(is_go118) {
 				func_end_value+=go_bin.get_address_value(pcheader_base, 8+pointer_size*2, pointer_size);
 			}
-			func_end_addr=go_bin.get_address(func_end_value);
+			if(is_wasm) {
+				// In WASM the "end PC" is the next func's runtime entry; we want a real byte
+				// size, so synthesize func_end = func_addr + actual code body size.
+				int func_idx=wasm_entry_to_func_idx(go_bin, func_list_base, func_addr_value, functab_field_size);
+				long size=go_bin.get_wasm_func_size(func_idx);
+				func_end_addr=go_bin.get_address(func_addr, size);
+			} else {
+				func_end_addr=go_bin.get_address(func_end_value);
+			}
 		} catch (BinaryAccessException e) {
 			throw new InvalidBinaryStructureException(String.format("Invalid FuncInfo tab: message=%s", e.getMessage()));
 		}
@@ -148,6 +173,8 @@ public class FuncInfo {
 	}
 
 	public long get_func_size() {
+		// In WASM, both addresses already point into the WasmLoader's CODE_BASE space
+		// (set up by parse_func_info_tab), so this subtraction yields the actual body size.
 		return get_info_tab().get_next_func_addr().getOffset()-get_info_tab().get_func_addr().getOffset();
 	}
 
@@ -168,6 +195,7 @@ public class FuncInfo {
 
 		int pointer_size=go_bin.get_pointer_size();
 		Address pcheader_base=go_bin.get_pcheader_base();
+		boolean is_wasm=go_bin.is_wasm();
 
 		long func_entry_value;
 		long text=0;
@@ -192,12 +220,17 @@ public class FuncInfo {
 		if (func_entry_value==0) {
 			throw new InvalidBinaryStructureException("Invalid FuncInfo.func_addr");
 		}
-		if (info_tab.get_func_addr().getOffset()+(is_go126?text:0)!=func_entry_value && !force) {
+		if (!is_wasm && info_tab.get_func_addr().getOffset()+(is_go126?text:0)!=func_entry_value && !force) {
 			throw new InvalidBinaryStructureException(String.format("FuncInfo.func_addr mismatch: %x != %x", info_tab.get_func_addr().getOffset(), func_entry_value));
 		}
 
 		try {
-			func_addr=go_bin.get_address(func_entry_value);
+			if (is_wasm) {
+				int func_idx=wasm_entry_to_func_idx(go_bin, func_list_base, func_entry_value, is_go118?4:pointer_size);
+				func_addr=go_bin.get_wasm_func_addr(func_idx);
+			} else {
+				func_addr=go_bin.get_address(func_entry_value);
+			}
 			name_offset=(int)go_bin.get_address_value(info_tab.get_info_addr(), is_go118?4:pointer_size, 4);
 			arg_size=(int)go_bin.get_address_value(info_tab.get_info_addr(), (is_go118?4:pointer_size)+4, 4);
 			pcsp_offset=(int)go_bin.get_address_value(info_tab.get_info_addr(), (is_go118?4:pointer_size)+3*4, 4);

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
@@ -72,6 +72,11 @@ public class FuncInfo {
 		long base_entry = go_bin.get_address_value(func_list_base, field_size);
 		// For Go ≥1.18, pcheader.textStart on WASM is 0, so we don't add it here either.
 		long delta = current_entry - base_entry;
+		// Support only up to 65536 functions
+		if ((delta & 0xffff) == 0) {
+			// go1.24 - go1.11
+			delta >>= 16;
+		}
 		return (int) (delta + go_bin.get_wasm_num_imports());
 	}
 

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/FuncInfo.java
@@ -64,20 +64,15 @@ public class FuncInfo {
 		return;
 	}
 
-	// Go WASM funtab encoding: each entry is a 32-bit "runtime funcEntry" value that
-	// increments by 1 between consecutive user functions, starting at some constant for
-	// the first entry. The mapping to wasm-module funcID is:
-	//     wasm_func_idx = (current_entry - first_entry) + num_imports
 	private static int wasm_entry_to_func_idx(GolangBinary go_bin, Address func_list_base, long current_entry, int field_size) throws BinaryAccessException {
 		long base_entry = go_bin.get_address_value(func_list_base, field_size);
-		// For Go ≥1.18, pcheader.textStart on WASM is 0, so we don't add it here either.
 		long delta = current_entry - base_entry;
 		// Support only up to 65536 functions
 		if ((delta & 0xffff) == 0) {
 			// go1.24 - go1.11
 			delta >>= 16;
 		}
-		return (int) (delta + go_bin.get_wasm_num_imports());
+		return (int) delta;
 	}
 
 	private FuncInfoTab parse_func_info_tab(GolangBinary go_bin, Address func_list_base, Address tab_addr) throws InvalidBinaryStructureException {

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
@@ -597,6 +597,30 @@ public class GolangBinary {
 		return program.getLanguage().getProcessor().toString().equals("RISCV");
 	}
 
+	public boolean is_wasm() {
+		return program.getLanguage().getProcessor().toString().equals("WebAssembly");
+	}
+
+	private WasmLayout wasm_layout;
+	private WasmLayout get_wasm_layout() {
+		if (wasm_layout == null) {
+			wasm_layout = new WasmLayout(this);
+		}
+		return wasm_layout;
+	}
+
+	public Address get_wasm_func_addr(int func_idx) throws BinaryAccessException {
+		return get_wasm_layout().get_func_addr(func_idx);
+	}
+
+	public long get_wasm_func_size(int func_idx) {
+		return get_wasm_layout().get_func_size(func_idx);
+	}
+
+	public int get_wasm_num_imports() {
+		return get_wasm_layout().get_num_imports();
+	}
+
 	public void disassemble(Address addr, long size) throws BinaryAccessException {
 		Address addr_end=get_address(addr, size);
 

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
@@ -617,10 +617,6 @@ public class GolangBinary {
 		return get_wasm_layout().get_func_size(func_idx);
 	}
 
-	public int get_wasm_num_imports() {
-		return get_wasm_layout().get_num_imports();
-	}
-
 	public void disassemble(Address addr, long size) throws BinaryAccessException {
 		Address addr_end=get_address(addr, size);
 

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/GolangBinary.java
@@ -598,7 +598,7 @@ public class GolangBinary {
 	}
 
 	public boolean is_wasm() {
-		return program.getLanguage().getProcessor().toString().equals("WebAssembly");
+		return get_wasm_layout().is_parse_successful();
 	}
 
 	private WasmLayout wasm_layout;

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
@@ -2,7 +2,6 @@ package golanganalyzerextension.gobinary;
 
 import ghidra.program.model.address.Address;
 import golanganalyzerextension.gobinary.exceptions.BinaryAccessException;
-import golanganalyzerextension.log.Logger;
 
 public class WasmLayout {
 
@@ -26,7 +25,6 @@ public class WasmLayout {
 
 	private final GolangBinary go_bin;
 	private CodeSection code_section;
-	private int num_imports;
 	private boolean ok;
 
 	private static class CodeSection {
@@ -69,10 +67,6 @@ public class WasmLayout {
 		return ok;
 	}
 
-	public int get_num_imports() {
-		return num_imports;
-	}
-
 	public Address get_func_addr(int func_idx) throws BinaryAccessException {
 		CodeFunction func = get_code_func(func_idx);
 		if (func == null) {
@@ -90,7 +84,7 @@ public class WasmLayout {
 		if (code_section == null) {
 			return null;
 		}
-		return code_section.get_func(func_idx - num_imports);
+		return code_section.get_func(func_idx);
 	}
 
 	// https://webassembly.github.io/spec/core/binary/modules.html
@@ -98,9 +92,8 @@ public class WasmLayout {
 		Address module_base = find_module_base();
 
 		long cursor = 8;
-		num_imports = 0;
 
-		while (code_section == null || num_imports == 0) {
+		while (code_section == null) {
 			long section_id = go_bin.get_address_value(module_base, cursor, 1);
 			cursor += 1;
 
@@ -110,9 +103,7 @@ public class WasmLayout {
 			long section_start = cursor;
 			long section_end = section_start + section_size;
 
-			if (section_id == SECTION_ID_IMPORT) {
-				num_imports = parse_imports(module_base, section_start);
-			} else if (section_id == SECTION_ID_CODE) {
+			if (section_id == SECTION_ID_CODE) {
 				code_section = parse_code(module_base, section_start);
 			}
 
@@ -141,63 +132,6 @@ public class WasmLayout {
 			cursor += body_size;
 		}
 		return new CodeSection(functions);
-	}
-
-	private int parse_imports(Address module_base, long start) throws BinaryAccessException {
-		long cursor = start;
-		long[] cnt_pair = read_uleb128(module_base, cursor);
-		int count = (int) cnt_pair[0];
-		cursor += cnt_pair[1];
-		int func_imports = 0;
-		for (int i = 0; i < count; i++) {
-			long[] mod_len = read_uleb128(module_base, cursor);
-			cursor += mod_len[1] + mod_len[0];
-			long[] nm_len = read_uleb128(module_base, cursor);
-			cursor += nm_len[1] + nm_len[0];
-			long kind = go_bin.get_address_value(module_base, cursor, 1);
-			cursor += 1;
-			// https://webassembly.github.io/spec/core/binary/types.html#binary-externtype
-			if (kind == EXTERN_TYPE_TYPEIDX) {
-				long[] type_pair = read_uleb128(module_base, cursor);
-				cursor += type_pair[1];
-				func_imports++;
-			} else if (kind == EXTERN_TYPE_TABLETYPE) {
-				cursor += 1;
-				long[] el = read_uleb128(module_base, cursor);
-				cursor += el[1];
-				long limit_flags = go_bin.get_address_value(module_base, cursor, 1);
-				cursor += 1;
-				long[] init = read_uleb128(module_base, cursor);
-				cursor += init[1];
-				// https://webassembly.github.io/spec/core/binary/types.html#limits
-				if ((limit_flags & 1) != 0) {
-					long[] max = read_uleb128(module_base, cursor);
-					cursor += max[1];
-				}
-			} else if (kind == EXTERN_TYPE_MEMTYPE) {
-				long limit_flags = go_bin.get_address_value(module_base, cursor, 1);
-				cursor += 1;
-				long[] init = read_uleb128(module_base, cursor);
-				cursor += init[1];
-				// https://webassembly.github.io/spec/core/binary/types.html#limits
-				if ((limit_flags & 1) != 0) {
-					long[] max = read_uleb128(module_base, cursor);
-					cursor += max[1];
-				}
-			} else if (kind == EXTERN_TYPE_GLOBALTYPE) {
-				// https://webassembly.github.io/spec/core/binary/types.html#global-types
-				// No support: valtype -> reftype
-				cursor += 1;
-				cursor += 1;
-			} else if (kind == EXTERN_TYPE_TAGTYPE) {
-				cursor += 1;
-				long[] x = read_uleb128(module_base, cursor);
-				cursor += x[1];
-			} else {
-				throw new BinaryAccessException(String.format("Unknown WASM import kind: %d", kind));
-			}
-		}
-		return func_imports;
 	}
 
 	private long[] read_uleb128(Address base, long offset) throws BinaryAccessException {

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
@@ -4,45 +4,69 @@ import ghidra.program.model.address.Address;
 import golanganalyzerextension.gobinary.exceptions.BinaryAccessException;
 import golanganalyzerextension.log.Logger;
 
-// Parses the WebAssembly module bytes that the Ghidra Wasm loader places at
-// ram:CODE_BASE in order to recover the funcID -> Ghidra-address mapping
-// the loader assigned. Needed because Go's WASM pclntab uses packed
-// pseudo-PCs of the form (funcID << 16), not flat memory addresses.
 public class WasmLayout {
 
-	public static final long IMPORT_BASE = 0x7f000000L;
-	public static final long CODE_BASE   = 0x80000000L;
+	public static final long SECTION_ID_IMPORT = 2;
+	public static final long SECTION_ID_CODE = 10;
+
+	public static final long EXTERN_TYPE_TYPEIDX = 0;
+	public static final long EXTERN_TYPE_TABLETYPE = 1;
+	public static final long EXTERN_TYPE_MEMTYPE = 2;
+	public static final long EXTERN_TYPE_GLOBALTYPE = 3;
+	public static final long EXTERN_TYPE_TAGTYPE = 4;
+
+	private static final byte[] WASM_MODULE_HEADER = new byte[] {
+		(byte) 0x00, (byte) 0x61, (byte) 0x73, (byte) 0x6d,
+		(byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+	};
+	private static final byte[] WASM_MODULE_HEADER_MASK = new byte[] {
+		(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+		(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+	};
 
 	private final GolangBinary go_bin;
-	private long[] func_addrs;
-	private long[] func_sizes;
+	private CodeSection code_section;
 	private int num_imports;
-	private boolean parsed;
 	private boolean ok;
+
+	private static class CodeSection {
+		private final CodeFunction[] functions;
+
+		CodeSection(CodeFunction[] functions) {
+			this.functions = functions;
+		}
+
+		CodeFunction get_func(int idx) {
+			if (idx < 0 || idx >= functions.length) {
+				return null;
+			}
+			return functions[idx];
+		}
+	}
+
+	private static class CodeFunction {
+		private final long addr;
+		private final long size;
+
+		CodeFunction(long addr, long size) {
+			this.addr = addr;
+			this.size = size;
+		}
+	}
 
 	public WasmLayout(GolangBinary go_bin) {
 		this.go_bin = go_bin;
-		this.parsed = false;
 		this.ok = false;
-	}
-
-	public boolean ensure_parsed() {
-		if (parsed) {
-			return ok;
-		}
-		parsed = true;
 		try {
 			parse();
 			ok = true;
 		} catch (BinaryAccessException e) {
-			Logger.append_message(String.format("Failed to parse WASM layout: %s", e.getMessage()));
 			ok = false;
 		}
-		return ok;
 	}
 
-	public int get_num_funcs() {
-		return func_addrs == null ? 0 : func_addrs.length;
+	public boolean is_parse_successful() {
+		return ok;
 	}
 
 	public int get_num_imports() {
@@ -50,39 +74,34 @@ public class WasmLayout {
 	}
 
 	public Address get_func_addr(int func_idx) throws BinaryAccessException {
-		if (!ensure_parsed() || func_idx < 0 || func_idx >= func_addrs.length) {
+		CodeFunction func = get_code_func(func_idx);
+		if (func == null) {
 			throw new BinaryAccessException(String.format("WASM funcID out of range: %d", func_idx));
 		}
-		return go_bin.get_address(func_addrs[func_idx]);
+		return go_bin.get_address(func.addr);
 	}
 
 	public long get_func_size(int func_idx) {
-		if (!ensure_parsed() || func_idx < 0 || func_idx >= func_sizes.length) {
-			return 0;
-		}
-		return func_sizes[func_idx];
+		CodeFunction func = get_code_func(func_idx);
+		return func == null ? 0 : func.size;
 	}
 
-	private void parse() throws BinaryAccessException {
-		Address module_base = go_bin.get_address(CODE_BASE);
-		long magic = go_bin.get_address_value(module_base, 0, 4);
-		if (magic != 0x6d736100L) {
-			throw new BinaryAccessException(String.format("Bad WASM magic: %x", magic));
+	private CodeFunction get_code_func(int func_idx) {
+		if (code_section == null) {
+			return null;
 		}
+		return code_section.get_func(func_idx - num_imports);
+	}
+
+	// https://webassembly.github.io/spec/core/binary/modules.html
+	private void parse() throws BinaryAccessException {
+		Address module_base = find_module_base();
 
 		long cursor = 8;
-		int[] code_offsets = null;
-		int[] code_sizes = null;
 		num_imports = 0;
-		boolean code_seen = false;
 
-		while (true) {
-			long section_id;
-			try {
-				section_id = go_bin.get_address_value(module_base, cursor, 1);
-			} catch (BinaryAccessException e) {
-				break;
-			}
+		while (code_section == null || num_imports == 0) {
+			long section_id = go_bin.get_address_value(module_base, cursor, 1);
 			cursor += 1;
 
 			long[] len_pair = read_uleb128(module_base, cursor);
@@ -91,47 +110,37 @@ public class WasmLayout {
 			long section_start = cursor;
 			long section_end = section_start + section_size;
 
-			if (section_id == 2) {
+			if (section_id == SECTION_ID_IMPORT) {
 				num_imports = parse_imports(module_base, section_start);
-			} else if (section_id == 10) {
-				long sub_cursor = section_start;
-				long[] cnt_pair = read_uleb128(module_base, sub_cursor);
-				int code_count = (int) cnt_pair[0];
-				sub_cursor += cnt_pair[1];
-				code_offsets = new int[code_count];
-				code_sizes = new int[code_count];
-				for (int i = 0; i < code_count; i++) {
-					long[] sz_pair = read_uleb128(module_base, sub_cursor);
-					int body_size = (int) sz_pair[0];
-					sub_cursor += sz_pair[1];
-					code_offsets[i] = (int) sub_cursor;
-					code_sizes[i] = body_size;
-					sub_cursor += body_size;
-				}
-				code_seen = true;
+			} else if (section_id == SECTION_ID_CODE) {
+				code_section = parse_code(module_base, section_start);
 			}
 
 			cursor = section_end;
-			if (code_seen && num_imports >= 0) {
-				if (section_id == 10) {
-					break;
-				}
-			}
 		}
+	}
 
-		int total = num_imports + (code_offsets == null ? 0 : code_offsets.length);
-		func_addrs = new long[total];
-		func_sizes = new long[total];
-		for (int i = 0; i < num_imports; i++) {
-			func_addrs[i] = IMPORT_BASE + 4L * i;
-			func_sizes[i] = 4;
+	private Address find_module_base() throws BinaryAccessException {
+		return go_bin.find_memory(null, WASM_MODULE_HEADER, WASM_MODULE_HEADER_MASK).orElseThrow(() ->
+			new BinaryAccessException("WASM module header not found")
+		);
+	}
+
+	private CodeSection parse_code(Address module_base, long start) throws BinaryAccessException {
+		long module_base_value = module_base.getOffset();
+		long cursor = start;
+		long[] cnt_pair = read_uleb128(module_base, cursor);
+		int code_count = (int) cnt_pair[0];
+		cursor += cnt_pair[1];
+		CodeFunction[] functions = new CodeFunction[code_count];
+		for (int i = 0; i < code_count; i++) {
+			long[] sz_pair = read_uleb128(module_base, cursor);
+			int body_size = (int) sz_pair[0];
+			cursor += sz_pair[1];
+			functions[i] = new CodeFunction(module_base_value + cursor, body_size);
+			cursor += body_size;
 		}
-		if (code_offsets != null) {
-			for (int i = 0; i < code_offsets.length; i++) {
-				func_addrs[num_imports + i] = CODE_BASE + code_offsets[i];
-				func_sizes[num_imports + i] = code_sizes[i];
-			}
-		}
+		return new CodeSection(functions);
 	}
 
 	private int parse_imports(Address module_base, long start) throws BinaryAccessException {
@@ -147,11 +156,12 @@ public class WasmLayout {
 			cursor += nm_len[1] + nm_len[0];
 			long kind = go_bin.get_address_value(module_base, cursor, 1);
 			cursor += 1;
-			if (kind == 0) {
+			// https://webassembly.github.io/spec/core/binary/types.html#binary-externtype
+			if (kind == EXTERN_TYPE_TYPEIDX) {
 				long[] type_pair = read_uleb128(module_base, cursor);
 				cursor += type_pair[1];
 				func_imports++;
-			} else if (kind == 1) {
+			} else if (kind == EXTERN_TYPE_TABLETYPE) {
 				cursor += 1;
 				long[] el = read_uleb128(module_base, cursor);
 				cursor += el[1];
@@ -159,22 +169,30 @@ public class WasmLayout {
 				cursor += 1;
 				long[] init = read_uleb128(module_base, cursor);
 				cursor += init[1];
+				// https://webassembly.github.io/spec/core/binary/types.html#limits
 				if ((limit_flags & 1) != 0) {
 					long[] max = read_uleb128(module_base, cursor);
 					cursor += max[1];
 				}
-			} else if (kind == 2) {
+			} else if (kind == EXTERN_TYPE_MEMTYPE) {
 				long limit_flags = go_bin.get_address_value(module_base, cursor, 1);
 				cursor += 1;
 				long[] init = read_uleb128(module_base, cursor);
 				cursor += init[1];
+				// https://webassembly.github.io/spec/core/binary/types.html#limits
 				if ((limit_flags & 1) != 0) {
 					long[] max = read_uleb128(module_base, cursor);
 					cursor += max[1];
 				}
-			} else if (kind == 3) {
+			} else if (kind == EXTERN_TYPE_GLOBALTYPE) {
+				// https://webassembly.github.io/spec/core/binary/types.html#global-types
+				// No support: valtype -> reftype
 				cursor += 1;
 				cursor += 1;
+			} else if (kind == EXTERN_TYPE_TAGTYPE) {
+				cursor += 1;
+				long[] x = read_uleb128(module_base, cursor);
+				cursor += x[1];
 			} else {
 				throw new BinaryAccessException(String.format("Unknown WASM import kind: %d", kind));
 			}

--- a/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
+++ b/GolangAnalyzerExtension/src/main/java/golanganalyzerextension/gobinary/WasmLayout.java
@@ -1,0 +1,203 @@
+package golanganalyzerextension.gobinary;
+
+import ghidra.program.model.address.Address;
+import golanganalyzerextension.gobinary.exceptions.BinaryAccessException;
+import golanganalyzerextension.log.Logger;
+
+// Parses the WebAssembly module bytes that the Ghidra Wasm loader places at
+// ram:CODE_BASE in order to recover the funcID -> Ghidra-address mapping
+// the loader assigned. Needed because Go's WASM pclntab uses packed
+// pseudo-PCs of the form (funcID << 16), not flat memory addresses.
+public class WasmLayout {
+
+	public static final long IMPORT_BASE = 0x7f000000L;
+	public static final long CODE_BASE   = 0x80000000L;
+
+	private final GolangBinary go_bin;
+	private long[] func_addrs;
+	private long[] func_sizes;
+	private int num_imports;
+	private boolean parsed;
+	private boolean ok;
+
+	public WasmLayout(GolangBinary go_bin) {
+		this.go_bin = go_bin;
+		this.parsed = false;
+		this.ok = false;
+	}
+
+	public boolean ensure_parsed() {
+		if (parsed) {
+			return ok;
+		}
+		parsed = true;
+		try {
+			parse();
+			ok = true;
+		} catch (BinaryAccessException e) {
+			Logger.append_message(String.format("Failed to parse WASM layout: %s", e.getMessage()));
+			ok = false;
+		}
+		return ok;
+	}
+
+	public int get_num_funcs() {
+		return func_addrs == null ? 0 : func_addrs.length;
+	}
+
+	public int get_num_imports() {
+		return num_imports;
+	}
+
+	public Address get_func_addr(int func_idx) throws BinaryAccessException {
+		if (!ensure_parsed() || func_idx < 0 || func_idx >= func_addrs.length) {
+			throw new BinaryAccessException(String.format("WASM funcID out of range: %d", func_idx));
+		}
+		return go_bin.get_address(func_addrs[func_idx]);
+	}
+
+	public long get_func_size(int func_idx) {
+		if (!ensure_parsed() || func_idx < 0 || func_idx >= func_sizes.length) {
+			return 0;
+		}
+		return func_sizes[func_idx];
+	}
+
+	private void parse() throws BinaryAccessException {
+		Address module_base = go_bin.get_address(CODE_BASE);
+		long magic = go_bin.get_address_value(module_base, 0, 4);
+		if (magic != 0x6d736100L) {
+			throw new BinaryAccessException(String.format("Bad WASM magic: %x", magic));
+		}
+
+		long cursor = 8;
+		int[] code_offsets = null;
+		int[] code_sizes = null;
+		num_imports = 0;
+		boolean code_seen = false;
+
+		while (true) {
+			long section_id;
+			try {
+				section_id = go_bin.get_address_value(module_base, cursor, 1);
+			} catch (BinaryAccessException e) {
+				break;
+			}
+			cursor += 1;
+
+			long[] len_pair = read_uleb128(module_base, cursor);
+			long section_size = len_pair[0];
+			cursor += len_pair[1];
+			long section_start = cursor;
+			long section_end = section_start + section_size;
+
+			if (section_id == 2) {
+				num_imports = parse_imports(module_base, section_start);
+			} else if (section_id == 10) {
+				long sub_cursor = section_start;
+				long[] cnt_pair = read_uleb128(module_base, sub_cursor);
+				int code_count = (int) cnt_pair[0];
+				sub_cursor += cnt_pair[1];
+				code_offsets = new int[code_count];
+				code_sizes = new int[code_count];
+				for (int i = 0; i < code_count; i++) {
+					long[] sz_pair = read_uleb128(module_base, sub_cursor);
+					int body_size = (int) sz_pair[0];
+					sub_cursor += sz_pair[1];
+					code_offsets[i] = (int) sub_cursor;
+					code_sizes[i] = body_size;
+					sub_cursor += body_size;
+				}
+				code_seen = true;
+			}
+
+			cursor = section_end;
+			if (code_seen && num_imports >= 0) {
+				if (section_id == 10) {
+					break;
+				}
+			}
+		}
+
+		int total = num_imports + (code_offsets == null ? 0 : code_offsets.length);
+		func_addrs = new long[total];
+		func_sizes = new long[total];
+		for (int i = 0; i < num_imports; i++) {
+			func_addrs[i] = IMPORT_BASE + 4L * i;
+			func_sizes[i] = 4;
+		}
+		if (code_offsets != null) {
+			for (int i = 0; i < code_offsets.length; i++) {
+				func_addrs[num_imports + i] = CODE_BASE + code_offsets[i];
+				func_sizes[num_imports + i] = code_sizes[i];
+			}
+		}
+	}
+
+	private int parse_imports(Address module_base, long start) throws BinaryAccessException {
+		long cursor = start;
+		long[] cnt_pair = read_uleb128(module_base, cursor);
+		int count = (int) cnt_pair[0];
+		cursor += cnt_pair[1];
+		int func_imports = 0;
+		for (int i = 0; i < count; i++) {
+			long[] mod_len = read_uleb128(module_base, cursor);
+			cursor += mod_len[1] + mod_len[0];
+			long[] nm_len = read_uleb128(module_base, cursor);
+			cursor += nm_len[1] + nm_len[0];
+			long kind = go_bin.get_address_value(module_base, cursor, 1);
+			cursor += 1;
+			if (kind == 0) {
+				long[] type_pair = read_uleb128(module_base, cursor);
+				cursor += type_pair[1];
+				func_imports++;
+			} else if (kind == 1) {
+				cursor += 1;
+				long[] el = read_uleb128(module_base, cursor);
+				cursor += el[1];
+				long limit_flags = go_bin.get_address_value(module_base, cursor, 1);
+				cursor += 1;
+				long[] init = read_uleb128(module_base, cursor);
+				cursor += init[1];
+				if ((limit_flags & 1) != 0) {
+					long[] max = read_uleb128(module_base, cursor);
+					cursor += max[1];
+				}
+			} else if (kind == 2) {
+				long limit_flags = go_bin.get_address_value(module_base, cursor, 1);
+				cursor += 1;
+				long[] init = read_uleb128(module_base, cursor);
+				cursor += init[1];
+				if ((limit_flags & 1) != 0) {
+					long[] max = read_uleb128(module_base, cursor);
+					cursor += max[1];
+				}
+			} else if (kind == 3) {
+				cursor += 1;
+				cursor += 1;
+			} else {
+				throw new BinaryAccessException(String.format("Unknown WASM import kind: %d", kind));
+			}
+		}
+		return func_imports;
+	}
+
+	private long[] read_uleb128(Address base, long offset) throws BinaryAccessException {
+		long value = 0;
+		int shift = 0;
+		long consumed = 0;
+		while (true) {
+			long b = go_bin.get_address_value(base, offset + consumed, 1) & 0xff;
+			value |= (b & 0x7f) << shift;
+			consumed++;
+			if ((b & 0x80) == 0) {
+				break;
+			}
+			shift += 7;
+			if (shift > 63) {
+				throw new BinaryAccessException("LEB128 too long");
+			}
+		}
+		return new long[] { value, consumed };
+	}
+}


### PR DESCRIPTION
I tried to use this extension for a goJS wasm binary (`GOOS=js GOARCH=wasm`) in conjunction with https://github.com/nneonneo/ghidra-wasm-plugin , but this did not work out of the box for stripped binaries. Also, using the latest master branch with the support for stripped binaries with a non-stripped wasm binary, this introduced duplicate functions at the wrong addresses for non-stripped binaries, symbols where not resolved correctly, and the annotations where not assigned at the correct positions.

This pull request adds support for handling wasm binaries (proper renaming of functions, source annotations, and references when calling functions).

Note, that the commits in this pull request were completely AI geneated by Claude Opus 4.7 on xhigh effort, and I do not have prior knowledge of writing Ghidra extensions/scripts, nor about WASM or go binary structure. This was made for me purely to get this extension working for a specific wasm binary. I would understand if you do not accept this pull request because of that.

<details>
  <summary>AI summary of first three commits</summary>
  When the analyzer is run on a Go binary compiled with GOOS=js GOARCH=wasm (tested against Go 1.26.3):

  1. Stripped WASM (-ldflags="-s -w"): every Go function was created at the wrong address inside the linear-memory block (e.g. ram:0x1000, ram:0x1001, …) instead of at the WasmLoader's CODE_BASE +
  body_offset placement. Renames like main.main landed on uninitialised stub addresses rather than the real WebAssembly code body.
  2. Non-stripped WASM: the WasmLoader had already created main.main (and friends) at the correct CODE_BASE address using the module's name section, but the Go analyzer then created a second function with
   the same Go name at the wrong address described above — producing duplicate symbols.

  Root cause

  Go's WASM pclntab funtab does not store the packed PC (funcID << 16) that older Go architectures use, and it does not store flat memory addresses either. Each 32-bit entry is a Go-internal "runtime
  funcEntry" value: it starts at a non-zero constant (e.g. 0x1000) for the first user function and increments by 1 between consecutive entries. Combined with the runtime entry's lack of a meaningful text
  field in pcheader for WASM, the existing parse_func_info_tab flowed the raw entry value into program.getAddressFactory().getDefaultAddressSpace().getAddress(value) and ended up inside Go's linear memory
   block.

  To map back to the WasmLoader's address space we need to know:
  - entry[0] — read once from the funtab base — gives the base of Go's runtime funcEntry numbering.
  - num_imports — read by parsing the Import section ourselves.
  - code_body_offset[i] for each non-imported function — read by parsing the Code section.

  Then wasm_funcID = (current_entry − entry[0]) + num_imports, and the matching Ghidra address is what the WasmLoader assigned: IMPORT_BASE + 4*idx for imports, CODE_BASE + body_offset[i] otherwise.

  Approach

  Three commits, each independently reviewable:

  1. Add WASM module parser and is_wasm() detection — pure infrastructure. New WasmLayout class reads the file bytes that the WasmLoader maps at ram:0x80000000, walks Import and Code sections, and
  produces a funcID → (address, size) table. GolangBinary gains is_wasm() and lazy accessors. No dependency on the Ghidra WASM plugin's classes. No behaviour change on its own.
  2. Translate WASM pclntab entries to WasmLoader addresses — uses the infrastructure to translate funtab entries inside FuncInfo.parse_func_info_tab and parse_func_info. Synthesises a real byte-size end
  address so get_func_size() is usable for instruction iteration. Short-circuits FunctionModifier.init_hardcode_functions on WASM (its memcpy/memset disassembly heuristics aren't meaningful on the
  WebAssembly ISA).
  3. Resolve WASM pointer constants to symbol names in decompile — separate readability improvement. Walks every i32.const/i64.const instruction in CODE_BASE+ functions; when the immediate value points at
   a known data symbol, attaches a DATA reference and an equate named &<symbol>. The equate is what gets the decompiler to substitute the name — a plain DATA reference isn't enough because WASM SLEIGH
  emits i64.const N as a literal constant copy.
  - *(stack-0x10) = 0x11660;
  + *(stack-0x10) = &datatype.String.string;
  - *(stack-8)    = 0x36878;
  + *(stack-8)    = &goss_hello_world_36878;

  All WASM-specific code paths are guarded by go_bin.is_wasm().
</details>